### PR TITLE
Update dependencies for win-kexp and refactor token stealing exploit:…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,21 +93,21 @@ dependencies = [
 name = "stack_buffer_overflow_acl_edit"
 version = "0.1.0"
 dependencies = [
- "win-kexp 0.1.0 (git+https://github.com/glslang/win-kexp.git)",
+ "win-kexp",
 ]
 
 [[package]]
 name = "stack_buffer_overflow_token_smep_no_kvashadow"
 version = "0.1.0"
 dependencies = [
- "win-kexp 0.1.0",
+ "win-kexp",
 ]
 
 [[package]]
 name = "stack_buffer_overflow_token_stealing"
 version = "0.1.0"
 dependencies = [
- "win-kexp 0.1.0 (git+https://github.com/glslang/win-kexp.git)",
+ "win-kexp",
 ]
 
 [[package]]
@@ -150,20 +150,7 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-dependencies = [
- "byte-strings",
- "goblin",
- "hex",
- "thiserror",
- "windows",
- "windows-core",
- "windows-strings 0.2.0",
-]
-
-[[package]]
-name = "win-kexp"
-version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp.git#b95b42158ab756dfa5245753ec6479b73fef25c8"
+source = "git+https://github.com/glslang/win-kexp.git#92d5455d2b08e2bee32baaea8c2bbbc0fa66f4d0"
 dependencies = [
  "byte-strings",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,21 +93,21 @@ dependencies = [
 name = "stack_buffer_overflow_acl_edit"
 version = "0.1.0"
 dependencies = [
- "win-kexp",
+ "win-kexp 0.1.0 (git+https://github.com/glslang/win-kexp.git)",
 ]
 
 [[package]]
 name = "stack_buffer_overflow_token_smep_no_kvashadow"
 version = "0.1.0"
 dependencies = [
- "win-kexp",
+ "win-kexp 0.1.0",
 ]
 
 [[package]]
 name = "stack_buffer_overflow_token_stealing"
 version = "0.1.0"
 dependencies = [
- "win-kexp",
+ "win-kexp 0.1.0 (git+https://github.com/glslang/win-kexp.git)",
 ]
 
 [[package]]
@@ -146,6 +146,19 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "win-kexp"
+version = "0.1.0"
+dependencies = [
+ "byte-strings",
+ "goblin",
+ "hex",
+ "thiserror",
+ "windows",
+ "windows-core",
+ "windows-strings 0.2.0",
+]
 
 [[package]]
 name = "win-kexp"

--- a/stack_buffer_overflow_token_stealing_smep_no_kvashadow/src/main.rs
+++ b/stack_buffer_overflow_token_stealing_smep_no_kvashadow/src/main.rs
@@ -2,7 +2,7 @@ use core::ffi::c_void;
 use std::iter;
 
 use win_kexp::rop::find_gadget_offset;
-use win_kexp::shellcode::token_stealing_shellcode;
+use win_kexp::shellcode::token_stealing_shellcode_smep_no_kvashadow;
 use win_kexp::util::bytes_to_hex_string;
 use win_kexp::{create_rop_chain, CTL_CODE, IOCTL};
 use win_kexp::{
@@ -67,7 +67,7 @@ fn exploit_stack_buffer_overflow_token_stealing_smep_no_kvashadow() {
     println!("[+] Ntoskrnl base address: 0x{ntoskrnl_address:x}");
 
     println!("[+] Building payload...");
-    let shellcode = token_stealing_shellcode();
+    let shellcode = token_stealing_shellcode_smep_no_kvashadow();
     let (payload, payload_len) = allocate_shellcode(shellcode.as_ptr(), shellcode.len());
 
     let payload_address = payload as u64;


### PR DESCRIPTION
… replace shellcode function and enhance Cargo.lock with detailed package information.