### PR TITLE
Refactor ROP chain generation in token stealing exploit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 [[package]]
 name = "win-kexp"
 version = "0.1.0"
-source = "git+https://github.com/glslang/win-kexp.git#bd2dae5fb8a760a6867824373b0b2063c025e199"
+source = "git+https://github.com/glslang/win-kexp.git#6bb47d9de1a2738e8ab07143a99713bb5dc6afbc"
 dependencies = [
  "byte-strings",
  "goblin",


### PR DESCRIPTION
- Introduced macro-based ROP chain generation for improved readability
- Replaced `create_rop_chain_to_buffer!` with `concat_rop_chain_to_buffer!`
- Modularized ROP chain creation with specific macro rules for different chain types
- Simplified chain composition and improved code structure